### PR TITLE
fix: somalier relate empty group file

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -194,7 +194,6 @@ multiqc:
         - "qc/multiqc/DNA_number.table.tsv"
         - "qc/somalier/somalier_relate.pairs.tsv"
         - "qc/somalier/somalier_relate.samples.tsv"
-        - "qc/somalier/somalier_relate.groups.tsv"
         - "qc/somalier/somalier_samples_mqc.tsv"
     RNA:
       config: "{{FLUFFY_HOME}}/config/multiqc_rna_config.yaml"

--- a/workflow/rules/somalier.smk
+++ b/workflow/rules/somalier.smk
@@ -206,7 +206,6 @@ rule somalier_relate:
         group="qc/somalier/somalier.groups",
     output:
         pairs="qc/somalier/somalier_relate.pairs.tsv",
-        groups="qc/somalier/somalier_relate.groups.tsv",
         samples="qc/somalier/somalier_relate.samples.tsv",
         html="qc/somalier/somalier_relate.html",
     log:


### PR DESCRIPTION
Group file is empty when there is no matched TN sample in the run and therefore a groups.tsv file will not get created. Removed from required output 
