### PR TITLE
fix: restore manta tables and add separate maxdepth BND recovery

### DIFF
--- a/workflow/scripts/export_to_xlsx_create_tables.py
+++ b/workflow/scripts/export_to_xlsx_create_tables.py
@@ -140,7 +140,7 @@ def first_info_value(record, key, default=None):
     return value
 
 
-def info_as_int(record, key, default=None):
+def info_as_int(record, key, default=0):
     value = first_info_value(record, key)
     if value is None:
         return default
@@ -150,7 +150,7 @@ def info_as_int(record, key, default=None):
         return default
 
 
-def info_as_float(record, key, default=None, decimals=None):
+def info_as_float(record, key, default=0.0, decimals=None):
     value = first_info_value(record, key)
     if value is None:
         return default

--- a/workflow/scripts/export_to_xlsx_create_tables.py
+++ b/workflow/scripts/export_to_xlsx_create_tables.py
@@ -433,6 +433,7 @@ def create_manta_tables(
         {"header": "manta_N_OCC"},
         {"header": "manta_T_OCC"},
         {"header": "manta_N_AF"},
+        {"header": "manta_T_AF"},
         {"header": "STR %"},
         {"header": "Paired-read freq"},
         {"header": "Spanning-read freq"},

--- a/workflow/scripts/export_to_xlsx_create_tables.py
+++ b/workflow/scripts/export_to_xlsx_create_tables.py
@@ -4,7 +4,7 @@ import gzip
 from pysam import VariantFile
 import re
 
-MIN_DEL_LEN = -100
+MIN_DEL_SIZE = 100
 
 
 # VEP fields in list to get index
@@ -191,6 +191,82 @@ def index_manta_annotation_fields(variantfile, annotation_id):
     return None
 
 
+def _info_values(record, key):
+    """Return all INFO values as a tuple."""
+    value = record.info.get(key)
+
+    if value in (None, "", "."):
+        return ()
+
+    if isinstance(value, (tuple, list)):
+        return tuple(value)
+
+    return (value,)
+
+
+def _extract_manta_annotations(record, ann_index, simple_ann_index):
+    """Extract compact gene labels and details, preferring SIMPLE_ANN."""
+    simple_annotations = _info_values(record, "SIMPLE_ANN")
+
+    if simple_annotations:
+        if not simple_ann_index:
+            raise ValueError(
+                "Manta VCF contains SIMPLE_ANN records "
+                "but no SIMPLE_ANN header definition"
+            )
+
+        gene_idx = simple_ann_index.index("GENE(s)")
+        transcript_idx = simple_ann_index.index("TRANSCRIPT")
+        detail_idx = simple_ann_index.index(
+            "DETAIL (exon losses, KNOWN_FUSION, "
+            "ON_PRIORITY_LIST, NOT_PRIORITISED)"
+        )
+
+        genes = []
+        details = []
+
+        for annotation in simple_annotations:
+            values = annotation.split("|")
+
+            gene_label = (
+                f"{values[gene_idx]}({values[transcript_idx]})"
+            )
+            if gene_label not in genes:
+                genes.append(gene_label)
+
+            detail = values[detail_idx]
+            if detail not in details:
+                details.append(detail)
+
+        return ", ".join(genes), ", ".join(details)
+
+    annotations = _info_values(record, "ANN")
+
+    if annotations:
+        if not ann_index:
+            raise ValueError(
+                "Manta VCF contains ANN records "
+                "but no ANN header definition"
+            )
+
+        gene_name_idx = ann_index.index("Gene_Name")
+        gene_id_idx = ann_index.index("Gene_ID")
+
+        genes = []
+
+        for annotation in annotations:
+            values = annotation.split("|")
+            gene_label = (
+                f"{values[gene_name_idx]}({values[gene_id_idx]})"
+            )
+            if gene_label not in genes:
+                genes.append(gene_label)
+
+        return ", ".join(genes), ""
+
+    return "NA", "NA"
+
+
 def extract_manta_vcf_values(record, ann_index, simple_ann_index, sample_tumor, sample_normal=""):
     return_dict = {}
     return_dict["filt_ann"] = ",".join(record.filter.keys())
@@ -201,59 +277,16 @@ def extract_manta_vcf_values(record, ann_index, simple_ann_index, sample_tumor, 
     return_dict["manta_n_af"] = info_as_float(record, "manta_N_AF")
     return_dict["manta_t_af"] = info_as_float(record, "manta_T_AF")
     return_dict["str_percent"] = info_as_float(record, "STR_PERCENT", default=0, decimals=2)
-
-    genes = []
-    details = []
-    try:
-        record.info["SIMPLE_ANN"]
-    except KeyError:
-        try:
-            record.info["ANN"]
-        except KeyError:
-            return_dict["genes"] = "NA"
-            return_dict["detail"] = "NA"
-        else:
-            if not ann_index:
-                raise ValueError("Manta VCF contains ANN records but no ANN header definition")
-            for annotation in record.info["ANN"]:
-                annotation_values = annotation.split("|")
-                gene_name_id = (
-                    annotation_values[ann_index.index("Gene_Name")] + "(" + annotation_values[ann_index.index("Gene_ID")] + ")"
-                )
-                if gene_name_id not in genes:
-                    genes.append(gene_name_id)
-
-            return_dict["genes"] = ", ".join(genes)
-            return_dict["detail"] = ""
-    else:
-        if not simple_ann_index:
-            raise ValueError("Manta VCF contains SIMPLE_ANN records but no SIMPLE_ANN header definition")
-        for annotation in record.info["SIMPLE_ANN"]:
-            annotation_values = annotation.split("|")
-            gene_name_id = (
-                annotation_values[simple_ann_index.index("GENE(s)")] + "("
-                + annotation_values[simple_ann_index.index("TRANSCRIPT")] + ")"
-            )
-            if gene_name_id not in genes:
-                genes.append(gene_name_id)
-            detail = annotation_values[
-                simple_ann_index.index("DETAIL (exon losses, KNOWN_FUSION, ON_PRIORITY_LIST, NOT_PRIORITISED)")
-            ]
-            if detail not in details:
-                details.append(detail)
-
-        return_dict["genes"] = ", ".join(genes)
-        return_dict["detail"] = ", ".join(details)
+    return_dict["genes"], return_dict["detail"] = _extract_manta_annotations(record, ann_index, simple_ann_index)
 
     # create a common id for BND mates
     mate_id = first_info_value(record, "MATEID")
     if mate_id is not None:
         return_dict["bnd_event_id"] = "|".join(sorted([return_dict["id"], str(mate_id)]))
     else:
-        # Missing MATEID represents a single-record event.
         return_dict["bnd_event_id"] = return_dict["id"]
 
-    # extract paired read and spannig read frequncies
+    # extract paired read and spanning read frequncies
     tumor_sample = record.samples[sample_tumor]
     return_dict["pr_freq"] = support_frequency(tumor_sample, "PR")
     return_dict["sr_freq"] = support_frequency(tumor_sample, "SR")
@@ -544,7 +577,11 @@ def create_manta_tables(
                 outline = outline + in_target
                 manta_tables["bnd"]["data"].append(outline)
 
-            elif "MantaDEL" in record_values["id"] and record_values["svlength"] <= MIN_DEL_LEN:
+            elif (
+                "MantaDEL" in record_values["id"]
+                and record_values["svlength"] is not None
+                and record_values["svlength"] <= -MIN_DEL_SIZE
+            ):
                 outline = [
                     str(record.contig),
                     int(record.pos),

--- a/workflow/scripts/export_to_xlsx_create_tables.py
+++ b/workflow/scripts/export_to_xlsx_create_tables.py
@@ -126,14 +126,79 @@ def extract_vcf_values(record, csq_index, sample_tumor, sample_normal=""):
     return return_dict
 
 
+#  Helper functions for value extraction
+def first_info_value(record, key, default=None):
+    """Return the first scalar INFO value, or default when absent."""
+    value = record.info.get(key)
+
+    if isinstance(value, (tuple, list)):
+        value = value[0] if value else None
+
+    if value in (None, "", "."):
+        return default
+
+    return value
+
+
+def info_as_int(record, key, default=None):
+    value = first_info_value(record, key)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def info_as_float(record, key, default=None, decimals=None):
+    value = first_info_value(record, key)
+    if value is None:
+        return default
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return default
+
+    return round(value, decimals) if decimals is not None else value
+
+
+def support_frequency(sample, field, default=None):
+    try:
+        values = sample.get(field)
+        if not values or len(values) != 2:
+            return default
+        ref_count, alt_count = values
+        if ref_count is None or alt_count is None:
+            return default
+        total = ref_count + alt_count
+        return alt_count / total if total > 0 else default
+    except (TypeError, ValueError):
+        return default
+
+
+def index_manta_annotation_fields(variantfile, annotation_id):
+    """Read the pipe-delimited field definition from a Manta INFO header."""
+    for header_record in variantfile.header.records:
+        if header_record.key != "INFO" or header_record.get("ID") != annotation_id:
+            continue
+        description = header_record.get("Description", "")
+        match = re.search(r"'([^']+)'", description)
+        if match:
+            return [field.strip() for field in match.group(1).split("|")]
+        raise ValueError(f"{annotation_id} header has no quoted field definition")
+    return None
+
+
 def extract_manta_vcf_values(record, ann_index, simple_ann_index, sample_tumor, sample_normal=""):
     return_dict = {}
     return_dict["filt_ann"] = ",".join(record.filter.keys())
-
-    try:
-        return_dict["id"] = ":".join(record.id.split(":")[0:2])
-    except KeyError:
-        return_dict["id"] = ""
+    return_dict["id"] = record.id or ""
+    return_dict["depth"] = first_info_value(record, "BND_DEPTH", default="")
+    return_dict["manta_n_occ"] = info_as_int(record, "manta_N_OCC")
+    return_dict["manta_t_occ"] = info_as_int(record, "manta_T_OCC")
+    return_dict["manta_n_af"] = info_as_float(record, "manta_N_AF")
+    return_dict["manta_t_af"] = info_as_float(record, "manta_T_AF")
+    return_dict["str_percent"] = info_as_float(record, "STR_PERCENT", default=0, decimals=2)
 
     genes = []
     details = []
@@ -146,6 +211,8 @@ def extract_manta_vcf_values(record, ann_index, simple_ann_index, sample_tumor, 
             return_dict["genes"] = "NA"
             return_dict["detail"] = "NA"
         else:
+            if not ann_index:
+                raise ValueError("Manta VCF contains ANN records but no ANN header definition")
             for annotation in record.info["ANN"]:
                 annotation_values = annotation.split("|")
                 gene_name_id = (
@@ -157,13 +224,13 @@ def extract_manta_vcf_values(record, ann_index, simple_ann_index, sample_tumor, 
             return_dict["genes"] = ", ".join(genes)
             return_dict["detail"] = ""
     else:
+        if not simple_ann_index:
+            raise ValueError("Manta VCF contains SIMPLE_ANN records but no SIMPLE_ANN header definition")
         for annotation in record.info["SIMPLE_ANN"]:
             annotation_values = annotation.split("|")
             gene_name_id = (
-                annotation_values[simple_ann_index.index("GENE(s)")]
-                + "("
-                + annotation_values[simple_ann_index.index("TRANSCRIPT")]
-                + ")"
+                annotation_values[simple_ann_index.index("GENE(s)")] + "("
+                + annotation_values[simple_ann_index.index("TRANSCRIPT")] + ")"
             )
             if gene_name_id not in genes:
                 genes.append(gene_name_id)
@@ -176,90 +243,27 @@ def extract_manta_vcf_values(record, ann_index, simple_ann_index, sample_tumor, 
         return_dict["genes"] = ", ".join(genes)
         return_dict["detail"] = ", ".join(details)
 
-    try:
-        return_dict["depth"] = record.info["BND_DEPTH"]
-    except KeyError:
-        return_dict["depth"] = ""
-
-    # -- Add manta_AF and STR % columns --
-    try:
-        n_occ_val = record.info.get("manta_N_OCC")
-        if n_occ_val is None:
-            return_dict["manta_n_occ"] = 0
-        else:
-            val = n_occ_val[0] if isinstance(n_occ_val, tuple) else n_occ_val
-            return_dict["manta_n_occ"] = int(val)
-    except (KeyError, ValueError, TypeError):
-        return_dict["manta_n_occ"] = 0
-
-    try:
-        t_occ_val = record.info.get("manta_T_OCC")
-        if t_occ_val is None:
-            return_dict["manta_t_occ"] = 0
-        else:
-            val = t_occ_val[0] if isinstance(t_occ_val, tuple) else t_occ_val
-            return_dict["manta_t_occ"] = int(val)
-    except (KeyError, ValueError, TypeError):
-        return_dict["manta_t_occ"] = 0
-
-    try:
-        str_val = record.info["STR_PERCENT"]
-        return_dict["str_percent"] = round(str_val[0] if isinstance(str_val, tuple) else str_val, 2)
-    except KeyError:
-        return_dict["str_percent"] = 0
-    # ----------------------------------------------------
-
-    try:
-        pr_values = record.samples[sample_tumor]["PR"]
-    except KeyError:
-        return_dict["pr_freq"] = ""
+    # create a common id for BND mates
+    mate_id = first_info_value(record, "MATEID")
+    if mate_id is not None:
+        return_dict["bnd_event_id"] = "|".join(sorted([return_dict["id"], str(mate_id)]))
     else:
-        pr_denominator, pr_numerator = pr_values
-        return_dict["pr_freq"] = pr_numerator / (pr_denominator + pr_numerator) if pr_denominator + pr_numerator != 0 else None
+        # Missing MATEID represents a single-record event.
+        return_dict["bnd_event_id"] = return_dict["id"]
 
-    try:
-        sr_values = record.samples[sample_tumor]["SR"]
-    except KeyError:
-        return_dict["sr_freq"] = ""
-    else:
-        sr_denominator, sr_numerator = sr_values
-        return_dict["sr_freq"] = sr_numerator / (sr_denominator + sr_numerator) if sr_denominator + sr_numerator != 0 else None
+    # extract paired read and spannig read frequncies
+    tumor_sample = record.samples[sample_tumor]
+    return_dict["pr_freq"] = support_frequency(tumor_sample, "PR")
+    return_dict["sr_freq"] = support_frequency(tumor_sample, "SR")
 
     if sample_normal:
-        try:
-            pr_values_n = record.samples[sample_normal]["PR"]
-        except KeyError:
-            return_dict["pr_freq_n"] = ""
-        else:
-            pr_denominator, pr_numerator = pr_values_n
-            return_dict["pr_freq_n"] = (
-                pr_numerator / (pr_denominator + pr_numerator) if pr_denominator + pr_numerator != 0 else None
-            )
+        normal_sample = record.samples[sample_normal]
+        return_dict["pr_freq_n"] = support_frequency(normal_sample, "PR")
+        return_dict["sr_freq_n"] = support_frequency(normal_sample, "SR")
 
-        try:
-            sr_values_n = record.samples[sample_normal]["SR"]
-        except KeyError:
-            return_dict["sr_freq_n"] = ""
-        else:
-            sr_denominator, sr_numerator = sr_values_n
-            return_dict["sr_freq_n"] = (
-                sr_numerator / (sr_denominator + sr_numerator) if sr_denominator + sr_numerator != 0 else None
-            )
-
-    try:
-        return_dict["svlength"] = record.info["SVLEN"][0]
-    except KeyError:
-        return_dict["svlength"] = ""
-
-    try:
-        return_dict["hom_len"] = record.info["HOMLEN"][0]
-    except KeyError:
-        return_dict["hom_len"] = ""
-
-    try:
-        return_dict["hom_seq"] = record.info["HOMSEQ"][0]
-    except KeyError:
-        return_dict["hom_seq"] = ""
+    return_dict["svlength"] = info_as_int(record, "SVLEN", default=None)
+    return_dict["hom_len"] = info_as_int(record, "HOMLEN", default=None)
+    return_dict["hom_seq"] = first_info_value(record, "HOMSEQ", default=None)
 
     return return_dict
 
@@ -406,11 +410,8 @@ def create_manta_tables(
     else:
         sample_normal = None
 
-    for header_row in vcf_file.header.records:
-        if "ID=ANN," in str(header_row):
-            ann_index = str(header_row).split("'")[1].strip().split(" | ")
-        elif "ID=SIMPLE_ANN," in str(header_row):
-            simple_ann_index = str(header_row).split("'")[1].strip().split(" | ")
+    ann_index = index_manta_annotation_fields(vcf_file, "ANN")
+    simple_ann_index = index_manta_annotation_fields(vcf_file, "SIMPLE_ANN")
 
     manta_tables = {
         "bnd": {"data": [], "headers": []},
@@ -423,6 +424,7 @@ def create_manta_tables(
         {"header": "Chr"},
         {"header": "Pos"},
         {"header": "MantaID"},
+        {"header": "BND Event ID"},
         {"header": "BreakEnd"},
         {"header": "Genes"},
         {"header": "Details"},
@@ -430,6 +432,7 @@ def create_manta_tables(
         {"header": "Annotation"},
         {"header": "manta_N_OCC"},
         {"header": "manta_T_OCC"},
+        {"header": "manta_N_AF"},
         {"header": "STR %"},
         {"header": "Paired-read freq"},
         {"header": "Spanning-read freq"},
@@ -445,6 +448,8 @@ def create_manta_tables(
         {"header": "Annotation"},
         {"header": "manta_N_OCC"},
         {"header": "manta_T_OCC"},
+        {"header": "manta_N_AF"},
+        {"header": "manta_T_AF"},
         {"header": "STR %"},
         {"header": "Paired-read freq"},
         {"header": "Spanning-read freq"},
@@ -462,6 +467,8 @@ def create_manta_tables(
         {"header": "Annotation"},
         {"header": "manta_N_OCC"},
         {"header": "manta_T_OCC"},
+        {"header": "manta_N_AF"},
+        {"header": "manta_T_AF"},
         {"header": "STR %"},
         {"header": "Paired-read freq"},
         {"header": "Spanning-read freq"},
@@ -480,6 +487,8 @@ def create_manta_tables(
         {"header": "Annotation"},
         {"header": "manta_N_OCC"},
         {"header": "manta_T_OCC"},
+        {"header": "manta_N_AF"},
+        {"header": "manta_T_AF"},
         {"header": "STR %"},
         {"header": "Paired-read freq"},
         {"header": "Spanning-read freq"},
@@ -512,6 +521,7 @@ def create_manta_tables(
                     str(record.contig),
                     int(record.pos),
                     record_values["id"],
+                    record_values["bnd_event_id"],
                     str(record.alts[0]),
                     record_values["genes"],
                     record_values["detail"],
@@ -519,6 +529,8 @@ def create_manta_tables(
                     record_values["filt_ann"],
                     record_values["manta_n_occ"],
                     record_values["manta_t_occ"],
+                    record_values["manta_n_af"],
+                    record_values["manta_t_af"],
                     record_values["str_percent"],
                     record_values["pr_freq"],
                     record_values["sr_freq"],
@@ -541,6 +553,8 @@ def create_manta_tables(
                     record_values["filt_ann"],
                     record_values["manta_n_occ"],
                     record_values["manta_t_occ"],
+                    record_values["manta_n_af"],
+                    record_values["manta_t_af"],
                     record_values["str_percent"],
                     record_values["pr_freq"],
                     record_values["sr_freq"],
@@ -565,6 +579,8 @@ def create_manta_tables(
                     record_values["filt_ann"],
                     record_values["manta_n_occ"],
                     record_values["manta_t_occ"],
+                    record_values["manta_n_af"],
+                    record_values["manta_t_af"],
                     record_values["str_percent"],
                     record_values["pr_freq"],
                     record_values["sr_freq"],
@@ -590,6 +606,8 @@ def create_manta_tables(
                     record_values["filt_ann"],
                     record_values["manta_n_occ"],
                     record_values["manta_t_occ"],
+                    record_values["manta_n_af"],
+                    record_values["manta_t_af"],
                     record_values["str_percent"],
                     record_values["pr_freq"],
                     record_values["sr_freq"],

--- a/workflow/scripts/export_to_xlsx_create_tables.py
+++ b/workflow/scripts/export_to_xlsx_create_tables.py
@@ -4,6 +4,8 @@ import gzip
 from pysam import VariantFile
 import re
 
+MIN_DEL_LEN = -100
+
 
 # VEP fields in list to get index
 def index_vep(variantfile):
@@ -542,7 +544,7 @@ def create_manta_tables(
                 outline = outline + in_target
                 manta_tables["bnd"]["data"].append(outline)
 
-            elif "MantaDEL" in record_values["id"] and record_values["svlength"] <= -100:
+            elif "MantaDEL" in record_values["id"] and record_values["svlength"] <= MIN_DEL_LEN:
                 outline = [
                     str(record.contig),
                     int(record.pos),

--- a/workflow/scripts/export_to_xlsx_manta.py
+++ b/workflow/scripts/export_to_xlsx_manta.py
@@ -344,9 +344,6 @@ if target_genes_path:
     target_genes = load_target_genes(target_genes_path)
 
 manta_tables_full = create_manta_tables(snakemake.input.manta, filter_flags, target_genes=target_genes)
-manta_tables_full = filter_maxdepth_by_support(manta_tables_full, 0.05)
-manta_tables_full["bnd"] = filter_complex_and_junk_bnd(manta_tables_full["bnd"], max_sites=4)
-
 
 # 2. Creating xlsx workbook
 workbook = xlsxwriter.Workbook(snakemake.output.xlsx)

--- a/workflow/scripts/export_to_xlsx_manta.py
+++ b/workflow/scripts/export_to_xlsx_manta.py
@@ -9,6 +9,7 @@ import os
 from collections import Counter
 
 MAX_OVERVIEW_NORMAL_AF = 0.2
+MAXDEPTH_RESCUE_MIN_SUPPORT = 0.05
 
 logging.basicConfig(
     format="{asctime} - {levelname} - {message}",
@@ -34,14 +35,26 @@ def convert_columns_to_letter(nr_columns):
 
 
 def load_target_genes(filepath):
-    genes = []
-    if filepath and os.path.exists(filepath):
-        try:
-            with open(filepath, 'r') as f:
-                genes = [line.strip() for line in f if line.strip()]
-            logging.info(f"Loaded {len(genes)} target genes from {filepath}")
-        except Exception as e:
-            logging.error(f"Could not load gene list: {e}")
+    if not filepath:
+        logging.warning("No target gene list supplied; target-panel summaries will be omitted.")
+        return []
+    
+    try:
+        with open(filepath, encoding="utf-8") as gene_file:
+            genes = [line.strip() for line in gene_file if line.strip()]
+    except FileNotFoundError as error:
+        raise FileNotFoundError(
+            f"Target gene list does not exist: {filepath}"
+        ) from error
+    except OSError as error:
+        raise OSError(
+            f"Could not read target gene list: {filepath}"
+        ) from error
+
+    if not genes:
+        raise ValueError(f"Target gene list is empty: {filepath}")
+
+    logging.info("Loaded %d target genes from %s", len(genes), filepath)
     return genes
 
 
@@ -126,22 +139,16 @@ def create_sheet(workbook, sheet_name, title, sample_name, filter_flags, table_d
     worksheet.write("A5", "Only calls NOT containing the following annotation are included: " + ", ".join(filter_flags))
     row_offset = 7
     if "Deletions" in sheet_name:
-        worksheet.write("A7", "Calls have to be longer than 100 bp to be included.")
+        worksheet.write("A7", "Deletions have to be longer than 100 bp to be included.")
         row_offset = 8
 
     headers = table_data["headers"]
     data = table_data["data"]
 
     # 1. Find columns
-    svdb_col_idx = -1
-    target_col_idx = -1
-    for idx, header_dict in enumerate(headers):
-        header_name = header_dict.get("header")
-
-        if header_name == "manta_N_AF":
-            svdb_col_idx = idx
-        elif header_name == "In Target Panel":
-            target_col_idx = idx
+    columns = _column_indexes(table_data)
+    svdb_col_idx = columns.get("manta_n_af")
+    target_col_idx = columns.get("in target panel")
 
     # xlsxwriter's add_table requires 1-based Excel coordinates (e.g., A7:K20)
     column_end = convert_columns_to_letter(len(headers))
@@ -157,21 +164,16 @@ def create_sheet(workbook, sheet_name, title, sample_name, filter_flags, table_d
     apply_compact_formatting(worksheet, headers, data)
 
     # Hide rows with high manta_N_AF, except target-gene variants
-    if svdb_col_idx != -1 and data:
+    if svdb_col_idx is not None and data:
         for i, row_data in enumerate(data):
             excel_row_index = row_offset + i
 
             is_target = (
-                target_col_idx != -1
+                target_col_idx is not None
                 and str(row_data[target_col_idx]).strip().lower() == "yes"
             )
 
-            try:
-                high_normal_af = float(row_data[svdb_col_idx]) > 0.2
-            except (ValueError, TypeError):
-                high_normal_af = False
-
-            if high_normal_af and not is_target:
+            if has_high_normal_af(row_data, svdb_col_idx) and not is_target:
                 worksheet.set_row(excel_row_index, options={"hidden": True})
 
     return worksheet
@@ -256,6 +258,13 @@ def known_fusion_events(table):
     return selected_rows
 
 
+def has_high_normal_af(row, normal_af_idx):
+    return (
+        normal_af_idx is not None
+        and _as_float(row[normal_af_idx], default=0.0) > MAX_OVERVIEW_NORMAL_AF
+    )
+
+
 def _filter_overview_rows_by_normal_af(table_data, selected_data, event_atomic=False):
     """
     Remove Overview candidates with normal-panel AF above the configured limit.
@@ -267,13 +276,10 @@ def _filter_overview_rows_by_normal_af(table_data, selected_data, event_atomic=F
     if normal_af_idx is None:
         return list(selected_data)
 
-    def has_high_normal_af(row):
-        return (_as_float(row[normal_af_idx], default=0.0) > MAX_OVERVIEW_NORMAL_AF)
-
     if not event_atomic:
-        return [row for row in selected_data if not has_high_normal_af(row)]
+        return [row for row in selected_data if not has_high_normal_af(row, normal_af_idx)]
 
-    excluded_event_ids = {_bnd_event_key(row, columns) for row in selected_data if has_high_normal_af(row)}
+    excluded_event_ids = {_bnd_event_key(row, columns) for row in selected_data if has_high_normal_af(row, normal_af_idx)}
 
     return [
         row
@@ -358,14 +364,8 @@ def write_target_summary(worksheet, start_row, title, table_data, format_heading
     headers = table_data["headers"]
     data = table_data.get("data", [])
 
-    target_col_idx = next(
-        (
-            idx
-            for idx, header in enumerate(headers)
-            if header.get("header") == "In Target Panel"
-        ),
-        None,
-    )
+    columns = _column_indexes(table_data)
+    target_col_idx = columns.get("in target panel")
 
     if target_col_idx is None:
         return start_row

--- a/workflow/scripts/export_to_xlsx_manta.py
+++ b/workflow/scripts/export_to_xlsx_manta.py
@@ -11,6 +11,33 @@ from collections import Counter
 MAX_OVERVIEW_NORMAL_AF = 0.2
 MAXDEPTH_RESCUE_MIN_SUPPORT = 0.05
 
+COLUMN_WIDTHS = {
+    "Sample Name": 24,
+    "Chr": 8,
+    "Pos": 11,
+    "EndPos": 11,
+    "Ref": 12,
+    "Alt": 24,
+    "SV Length": 11,
+    "MantaID": 24,
+    "BND Event ID": 30,
+    "BreakEnd": 24,
+    "Genes": 26,
+    "Details": 20,
+    "Hom Length": 11,
+    "Hom Sequence": 18,
+    "Annotation": 16,
+    "Depth": 10,
+    "manta_N_OCC": 12,
+    "manta_T_OCC": 12,
+    "manta_N_AF": 10,
+    "manta_T_AF": 10,
+    "STR %": 8,
+    "Paired-read freq": 16,
+    "Spanning-read freq": 18,
+    "In Target Panel": 16,
+}
+
 logging.basicConfig(
     format="{asctime} - {levelname} - {message}",
     style="{",
@@ -92,32 +119,11 @@ def format_manta_table(table, sample_name, format_2dec):
 
 
 def apply_compact_formatting(worksheet, headers, data):
-    """
-    Scans the data and applies sets column widths based on header name and content.
-    """
-    for col_idx, h in enumerate(headers):
-        header_str = str(h.get("header", ""))
-        max_len = len(header_str)
-
-        # Sample the first 100 rows to find max content length
-        for row in data[:100]:
-            if col_idx < len(row) and row[col_idx] is not None:
-                max_len = max(max_len, len(str(row[col_idx])))
-
-        # Apply compact constraints based on column type
-        lower_header = header_str.lower()
-        if "freq" in lower_header or "af" in lower_header or "chr" in lower_header:
-            final_width = 6
-        elif "pos" in lower_header or "length" in lower_header:
-            final_width = 12
-        elif "mantaid" in lower_header:
-            final_width = 16
-        elif "gene" in lower_header or "sample" in lower_header:
-            final_width = 20
-        else:
-            final_width = min(max_len + 2, 35)  # Allow slightly longer text cols but cap at 35
-
-        worksheet.set_column(col_idx, col_idx, final_width)
+    """Apply stable, field-specific widths to an exported table."""
+    for col_idx, header in enumerate(headers):
+        name = header.get("header", "")
+        width = COLUMN_WIDTHS.get(name, 14)
+        worksheet.set_column(col_idx, col_idx, width)
 
 
 def create_sheet(workbook, sheet_name, title, sample_name, filter_flags, table_data, set_cols=None):
@@ -126,11 +132,6 @@ def create_sheet(workbook, sheet_name, title, sample_name, filter_flags, table_d
 
     worksheet = workbook.add_worksheet(sheet_name)
     format_heading = workbook.add_format({"bold": True, "font_size": 18})
-
-    # Set column widths if specified
-    if set_cols:
-        for col_range, width in set_cols.items():
-            worksheet.set_column(col_range, width)
 
     worksheet.write("A1", title, format_heading)
     worksheet.write("A3", "Sample: " + str(sample_name))

--- a/workflow/scripts/export_to_xlsx_manta.py
+++ b/workflow/scripts/export_to_xlsx_manta.py
@@ -3,7 +3,6 @@
 from export_to_xlsx_create_tables import *
 import xlsxwriter
 import datetime
-from pysam import VariantFile
 import sys
 import logging
 import os
@@ -109,71 +108,82 @@ def apply_compact_formatting(worksheet, headers, data):
         worksheet.set_column(col_idx, col_idx, final_width)
 
 
-def write_target_summary(worksheet, start_row, title, table_data, sample_name, format_heading):
+def write_target_summary(worksheet, start_row, title, table_data, format_heading, event_atomic=False):
     """
-    Helper function to write a summary table on the Overview sheet
-    containing ONLY the variants where 'In Target Panel' is 'Yes' and manta_n_AF <= 0.2.
+    Write variants annotated as belonging to the target panel.
+
+    When event_atomic is True, all rows belonging to a selected BND event
+    are included if at least one breakend is in the target panel.
     """
     if not table_data or "headers" not in table_data:
         return start_row
 
     headers = table_data["headers"]
-    data = table_data["data"]
+    data = table_data.get("data", [])
 
-    # 1. Find the target column
-    target_col_idx = -1
-    svdb_col_idx = -1
-    for idx, h in enumerate(headers):
-        if h.get("header") == "In Target Panel":
-            target_col_idx = idx
-        elif h.get("header") == "manta_N_AF":
-            svdb_col_idx = idx
+    target_col_idx = next(
+        (
+            idx
+            for idx, header in enumerate(headers)
+            if header.get("header") == "In Target Panel"
+        ),
+        None,
+    )
 
-    if target_col_idx == -1:
-        return start_row  # Target column not found, skip
+    if target_col_idx is None:
+        return start_row
 
-    # 2. Extract target data
-    target_data = []
-    for row in data:
-        if row[target_col_idx] == "Yes":
-            keep_variant = True
+    target_data = [
+        row
+        for row in data
+        if str(row[target_col_idx]).strip().lower() == "yes"
+    ]
 
-            if svdb_col_idx != -1:
-                af_val = row[svdb_col_idx]
-                if af_val is not None and str(af_val).strip() != "":
-                    try:
-                        # Convert string/int/float to float. If > 0.2, discard it.
-                        if float(af_val) > 0.2:
-                            keep_variant = False
-                    except (ValueError, TypeError):
-                        pass
+    if event_atomic and target_data:
+        columns = _column_indexes(table_data)
 
-            if keep_variant:
-                target_data.append(row)
+        selected_event_ids = {
+            _bnd_event_key(row, columns)
+            for row in target_data
+        }
 
-    # Write the title
+        target_data = [
+            row
+            for row in data
+            if _bnd_event_key(row, columns) in selected_event_ids
+        ]
+
     worksheet.write(start_row, 0, title, format_heading)
-    table_start_idx = start_row + 2  # Skip a line after title
+    table_start_idx = start_row + 2
 
     if not target_data:
-        worksheet.write(table_start_idx, 0, "Inga target-varianter hittades för denna typ.")
+        worksheet.write(
+            table_start_idx,
+            0,
+            "Inga target-varianter hittades för denna typ.",
+        )
         return table_start_idx + 3
 
-    # Calculate Excel table coordinates
     column_end = convert_columns_to_letter(len(headers))
     excel_start_row = table_start_idx + 1
     excel_end_row = excel_start_row + len(target_data)
     table_area = f"A{excel_start_row}:{column_end}{excel_end_row}"
 
-    # Draw the table
     worksheet.add_table(
         table_area,
-        {"columns": headers, "data": target_data, "style": "Table Style Light 1"},
+        {
+            "columns": headers,
+            "data": target_data,
+            "style": "Table Style Light 1",
+        },
     )
 
-    # Apply compact formatting to the summary table
-    apply_compact_formatting(worksheet, headers, target_data)
-    # Return the next available row (with some margin)
+    apply_compact_formatting(
+        worksheet,
+        headers,
+        target_data,
+    )
+
     return table_start_idx + len(target_data) + 4
 
 
@@ -192,7 +202,6 @@ def create_sheet(workbook, sheet_name, title, sample_name, filter_flags, table_d
     worksheet.write("A1", title, format_heading)
     worksheet.write("A3", "Sample: " + str(sample_name))
     worksheet.write("A5", "Only calls NOT containing the following annotation are included: " + ", ".join(filter_flags))
-    worksheet.write("A6", "MaxDepth calls are only included if they have PR or SR support >= 5% and manta_N_OCC = 0")
     row_offset = 7
     if "Deletions" in sheet_name:
         worksheet.write("A7", "Calls have to be longer than 100 bp to be included.")
@@ -203,9 +212,14 @@ def create_sheet(workbook, sheet_name, title, sample_name, filter_flags, table_d
 
     # 1. Find columns
     svdb_col_idx = -1
+    target_col_idx = -1
     for idx, header_dict in enumerate(headers):
-        if header_dict.get("header") == "manta_N_AF":
+        header_name = header_dict.get("header")
+
+        if header_name == "manta_N_AF":
             svdb_col_idx = idx
+        elif header_name == "In Target Panel":
+            target_col_idx = idx
 
     # xlsxwriter's add_table requires 1-based Excel coordinates (e.g., A7:K20)
     column_end = convert_columns_to_letter(len(headers))
@@ -220,105 +234,270 @@ def create_sheet(workbook, sheet_name, title, sample_name, filter_flags, table_d
 
     apply_compact_formatting(worksheet, headers, data)
 
-    # 2. Hide rows with High manta_N_AF (but leave target genes visible)
-    if svdb_col_idx != -1 and len(data) > 0:
+    # Hide rows with high manta_N_AF, except target-gene variants
+    if svdb_col_idx != -1 and data:
         for i, row_data in enumerate(data):
             excel_row_index = row_offset + i
+
+            is_target = (
+                target_col_idx != -1
+                and str(row_data[target_col_idx]).strip().lower() == "yes"
+            )
+
             try:
-                if float(row_data[svdb_col_idx]) > 0.2:
-                    worksheet.set_row(excel_row_index, options={'hidden': True})
+                high_normal_af = float(row_data[svdb_col_idx]) > 0.2
             except (ValueError, TypeError):
-                pass
+                high_normal_af = False
+
+            if high_normal_af and not is_target:
+                worksheet.set_row(excel_row_index, options={"hidden": True})
 
     return worksheet
 
 
-def filter_complex_and_junk_bnd(table, max_sites=4):
-    if not table or "headers" not in table or not table["data"]:
-        return table
+def _column_indexes(table):
+    return {
+        str(header.get("header", "")).lower(): index
+        for index, header in enumerate(table.get("headers", []))
+    }
 
-    headers = table["headers"]
-    data = table["data"]
 
-    chr_idx = -1
-    partner_idx = -1
-    id_idx = -1
+def _as_float(value, default=0.0):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
 
-    for i, h in enumerate(headers):
-        header_name = str(h.get("header", "")).lower()
-        if header_name == "chr":
-            chr_idx = i
-        elif header_name in {"breakend", "alt"}:
-            partner_idx = i
-        elif header_name == "mantaid":
-            id_idx = i
 
-    if chr_idx == -1 or id_idx == -1:
-        logging.warning("Could not filter BND table, missing Chr or MantaID")
-        return table
+def _annotation_flags(row, column_indexes):
+    return {
+        flag.strip()
+        for flag in str(row[column_indexes["annotation"]]).split(",")
+        if flag.strip()
+    }
 
-    id_counts = Counter(str(row[id_idx]) for row in data)
-    junk_keywords = ["chrun", "random", "gl0", "ki2"]
 
-    filtered_data = []
-    for row in data:
-        chr_val = str(row[chr_idx]).lower()
-        partner_val = str(row[partner_idx]).lower() if partner_idx != -1 else ""
-        manta_id = str(row[id_idx])
+def _bnd_event_key(row, column_indexes):
+    """Return a stable BND event key, falling back to a single-record event."""
+    event_idx = column_indexes.get("bnd event id")
+    if event_idx is not None and row[event_idx]:
+        return str(row[event_idx])
 
-        is_junk_contig = (
-            any(k in chr_val for k in junk_keywords) or
-            any(k in partner_val for k in junk_keywords)
+    id_idx = column_indexes.get("mantaid")
+    return str(row[id_idx]) if id_idx is not None else id(row)
+
+
+def _is_junk_bnd(row, column_indexes):
+    chr_idx = column_indexes.get("chr")
+    partner_idx = column_indexes.get("breakend", column_indexes.get("alt"))
+
+    chr_value = str(row[chr_idx]).lower() if chr_idx is not None else ""
+    partner_value = str(row[partner_idx]).lower() if partner_idx is not None else ""
+
+    return any(
+        keyword in value
+        for keyword in ("chrun", "random", "gl0", "ki2")
+        for value in (chr_value, partner_value)
+    )
+
+
+def known_fusion_events(table):
+    """Return complete BND events containing a KNOWN_FUSION annotation."""
+    columns = _column_indexes(table)
+    details_idx = columns.get("details")
+
+    if details_idx is None:
+        return []
+
+    events = {}
+    for row in table.get("data", []):
+        event_id = _bnd_event_key(row, columns)
+        events.setdefault(event_id, []).append(row)
+
+    selected_rows = []
+
+    for event_rows in events.values():
+        has_known_fusion = any(
+            "KNOWN_FUSION" in {
+                part.strip()
+                for part in str(row[details_idx]).split(",")
+            }
+            for row in event_rows
         )
 
-        has_too_many_sites = id_counts[manta_id] > max_sites
-        # use >= if you want 4-or-more removed
-
-        if not is_junk_contig and not has_too_many_sites:
-            filtered_data.append(row)
-
-    table["data"] = filtered_data
-    logging.info("Top repeated BND IDs: %s", id_counts.most_common(10))
-    return table
-
-
-def filter_maxdepth_by_support(tables_dict, min_support=0.05):
-    """
-    Removes variants flagged with 'MaxDepth' UNLESS their PR or SR frequency is >= min_support.
-    """
-    for sv_type in ["bnd", "del", "dup", "ins"]:
-        table_data = tables_dict[sv_type]
-        if not table_data["data"]:
+        if not has_known_fusion:
             continue
 
-        headers = [h["header"] for h in table_data["headers"]]
-        try:
-            ann_idx = headers.index("Annotation")
-            pr_idx = headers.index("Paired-read freq")
-            sr_idx = headers.index("Spanning-read freq")
-            occ_idx = headers.index("manta_N_OCC")
-        except ValueError:
+        # Include both breakends of the event.
+        selected_rows.extend(event_rows)
+
+    return selected_rows
+
+
+def write_known_fusion_summary(worksheet, start_row, title, headers, selected_data, format_heading):
+    """Write selected KNOWN_FUSION BND events to the Overview sheet."""
+    if not selected_data:
+        return start_row
+
+    worksheet.write(start_row, 0, title, format_heading)
+    table_start_row = start_row + 2
+
+    column_end = convert_columns_to_letter(len(headers))
+    excel_start_row = table_start_row + 1
+    excel_end_row = excel_start_row + len(selected_data)
+    table_area = f"A{excel_start_row}:{column_end}{excel_end_row}"
+
+    worksheet.add_table(
+        table_area,
+        {
+            "columns": headers,
+            "data": selected_data,
+            "style": "Table Style Light 1",
+        },
+    )
+
+    apply_compact_formatting(worksheet, headers, selected_data)
+
+    return table_start_row + len(selected_data) + 4
+
+
+def create_maxdepth_bnd_rescue_table(tables_dict, blocking_filter_flags, min_support=0.05):
+    """
+    Return BND events classified as MaxDepth if they pass our rescue criteria.
+
+    The input tables should contain all BND records so that MATEID-linked
+    partners are available. An event is rescued only when:
+
+    - at least one breakpoint is flagged MaxDepth;
+    - no event row has another blocking filter;
+    - every MaxDepth breakpoint has PR or SR frequency >= min_support;
+    - no MaxDepth breakpoint is present in the normal panel;
+    - neither breakpoint points to a junk/alternate contig.
+
+    When accepted, every row belonging to the BND event is returned.
+    """
+    if not 0 <= min_support <= 1:
+        raise ValueError("min_support must be between 0 and 1")
+
+    bnd_table = tables_dict.get("bnd", {"headers": [], "data": []})
+    rescue_table = {
+        "headers": [
+            header.copy()
+            for header in bnd_table.get("headers", [])
+        ],
+        "data": [],
+    }
+
+    if not bnd_table.get("data"):
+        return rescue_table
+
+    columns = _column_indexes(bnd_table)
+
+    required_columns = {
+        "bnd event id",
+        "chr",
+        "annotation",
+        "paired-read freq",
+        "spanning-read freq",
+        "manta_n_occ",
+    }
+
+    missing_columns = required_columns - columns.keys()
+
+    if "breakend" not in columns and "alt" not in columns:
+        missing_columns.add("breakend/alt")
+
+    if missing_columns:
+        raise ValueError(
+            "Cannot apply MaxDepth rescue to BND table; "
+            f"missing columns: {', '.join(sorted(missing_columns))}"
+        )
+
+    events = {}
+    for row in bnd_table["data"]:
+        event_id = _bnd_event_key(row, columns)
+        events.setdefault(event_id, []).append(row)
+
+    rescue_stats = Counter()
+
+    for event_rows in events.values():
+        maxdepth_rows = [
+            row
+            for row in event_rows
+            if "MaxDepth" in _annotation_flags(row, columns)
+        ]
+
+        if not maxdepth_rows:
             continue
 
-        filtered_data = []
-        for row in table_data["data"]:
-            annotation = str(row[ann_idx])
+        rescue_stats["candidate_events"] += 1
 
-            # Check if variant is flagged with MaxDepth
-            if "MaxDepth" in annotation:
-                # Safely extract frequency floats (they might be "" if no PR/SR was found)
-                pr_freq = row[pr_idx] if isinstance(row[pr_idx], float) else 0.0
-                sr_freq = row[sr_idx] if isinstance(row[sr_idx], float) else 0.0
+        has_other_blocking_filter = any(
+            _annotation_flags(row, columns) & blocking_filter_flags
+            for row in event_rows
+        )
 
-                # Keep it only if support meets our threshold
-                if (pr_freq >= min_support or sr_freq >= min_support) and row[occ_idx] == 0:
-                    filtered_data.append(row)
-            else:
-                # Keep all other non-MaxDepth rows normally
-                filtered_data.append(row)
+        all_maxdepth_rows_have_support = all(
+            _as_float(row[columns["paired-read freq"]]) >= min_support
+            or _as_float(row[columns["spanning-read freq"]]) >= min_support
+            for row in maxdepth_rows
+        )
 
-        tables_dict[sv_type]["data"] = filtered_data
-    return tables_dict
+        maxdepth_row_has_normal_panel_hit = any(
+            _as_float(row[columns["manta_n_occ"]]) != 0
+            for row in maxdepth_rows
+        )
+
+        has_junk_contig = any(
+            _is_junk_bnd(row, columns)
+            for row in event_rows
+        )
+
+        if has_other_blocking_filter:
+            rescue_stats["other_filter"] += 1
+        elif not all_maxdepth_rows_have_support:
+            rescue_stats["low_support"] += 1
+        elif maxdepth_row_has_normal_panel_hit:
+            rescue_stats["normal_panel"] += 1
+        elif has_junk_contig:
+            rescue_stats["junk_contig"] += 1
+        else:
+            rescue_table["data"].extend(event_rows)
+            rescue_stats["rescued_events"] += 1
+            rescue_stats["rescued_records"] += len(event_rows)
+
+    if rescue_stats:
+        logging.info(
+            "MaxDepth rescue for BND: %s",
+            dict(rescue_stats),
+        )
+
+    return rescue_table
+
+
+def write_maxdepth_rescue_summary(worksheet, start_row, title, table_data, format_heading):
+    """Write accepted MaxDepth BND rescue calls to the Overview sheet."""
+    if not table_data or not table_data.get("data"):
+        return start_row
+
+    headers = table_data["headers"]
+    data = table_data["data"]
+
+    worksheet.write(start_row, 0, title, format_heading)
+    table_start_row = start_row + 2
+
+    column_end = convert_columns_to_letter(len(headers))
+    excel_start_row = table_start_row + 1
+    excel_end_row = excel_start_row + len(data)
+    table_area = f"A{excel_start_row}:{column_end}{excel_end_row}"
+
+    worksheet.add_table(
+        table_area,
+        {"columns": headers, "data": data, "style": "Table Style Light 1"},
+    )
+    apply_compact_formatting(worksheet, headers, data)
+
+    return table_start_row + len(data) + 4
 
 
 """ MAIN EXECUTION """
@@ -327,15 +506,7 @@ def filter_maxdepth_by_support(tables_dict, min_support=0.05):
 logging.info(f"Prepping data, such as loading {snakemake.input.manta}=")
 sample_name = snakemake.output.xlsx.split("/")[-1].split(".manta.xlsx")[0]
 
-filter_flags = ["MinQUAL", "MinGQ", "MinSomaticScore", "Ploidy", "MaxMQ0Frac", "NoPairSupport", "SampleFT", "HomRef"]
-
-manta_N_total, manta_T_total = 0, 0
-with VariantFile(snakemake.input.manta) as vcf:
-    for rec in vcf:
-        if "manta_N_OCC" in rec.info and rec.info.get("manta_N_AF") > 0:
-            manta_N_total = int(round(rec.info["manta_N_OCC"] / rec.info["manta_N_AF"]))
-            manta_T_total = int(round(rec.info["manta_T_OCC"] / rec.info["manta_T_AF"]))
-            break
+filter_flags = ["MinQUAL", "MinGQ", "MinSomaticScore", "Ploidy", "MaxMQ0Frac", "NoPairSupport", "SampleFT", "HomRef", "MaxDepth"]
 
 # Load target genes for easy filtering in Excel
 target_genes = []
@@ -344,6 +515,13 @@ if target_genes_path:
     target_genes = load_target_genes(target_genes_path)
 
 manta_tables_full = create_manta_tables(snakemake.input.manta, filter_flags, target_genes=target_genes)
+manta_tables_all = create_manta_tables(snakemake.input.manta, avoid_filterflags=[], target_genes=target_genes)
+blocking_filter_flags = set(filter_flags) - {"MaxDepth"}
+manta_tables_maxdepth = create_maxdepth_bnd_rescue_table(
+    manta_tables_all,
+    blocking_filter_flags,
+    min_support=0.05,
+)
 
 # 2. Creating xlsx workbook
 workbook = xlsxwriter.Workbook(snakemake.output.xlsx)
@@ -356,6 +534,8 @@ format_2dec = workbook.add_format({"num_format": "0.00"})
 
 for sv_key in ["del", "ins", "dup", "bnd"]:
     format_manta_table(manta_tables_full[sv_key], sample_name, format_2dec)
+
+format_manta_table(manta_tables_maxdepth, sample_name, format_2dec)
 
 panel_tables_dict = {}
 for vcf in snakemake.input.vcfs_bed:
@@ -388,8 +568,7 @@ create_sheet(
 for vcf in snakemake.input.vcfs_bed:
     panel = vcf.split(".")[-3]
     logging.debug(f"Creating {panel} sheet")
-    panel_tables = create_manta_tables(vcf, filter_flags, target_genes=target_genes)
-    panel_tables["bnd"] = filter_complex_and_junk_bnd(panel_tables["bnd"], max_sites=4)
+    panel_tables = panel_tables_dict[panel]
     sheet_title = "Translocations in " + panel.upper() + " genes"
     sheet_name = "Translocations " + panel.upper()
     create_sheet(workbook, sheet_name, sheet_title, sample_name, filter_flags, panel_tables["bnd"], {"B:B": 12, "C:D": 15})
@@ -431,8 +610,7 @@ if target_genes:
     genes_string = ", ".join(target_genes)
     worksheet_overview.write(row_idx + 6, 0,
                              f"Target Genes filter added: {len(target_genes)} genes loaded - [{genes_string}]")
-worksheet_overview.write(row_idx + 8, 0,
-                         f"Number of samples in manta_N: {manta_N_total} and manta_T: {manta_T_total}")
+
 worksheet_overview.write(row_idx + 9, 0,
                          "Only calls NOT containing the following annotation are included: " + ", ".join(filter_flags))
 
@@ -457,8 +635,31 @@ for sv_key, sv_title in summaries:
         row_idx,
         sv_title,
         manta_tables_full[sv_key],
-        sample_name,
-        format_bold
+        format_bold,
+        event_atomic=(sv_key == "bnd"),
+    )
+
+known_fusion_rows = known_fusion_events(manta_tables_full["bnd"])
+
+if known_fusion_rows:
+    row_idx += 2
+    row_idx = write_known_fusion_summary(
+        worksheet_overview,
+        row_idx,
+        "Translocations (KNOWN_FUSION)",
+        manta_tables_full["bnd"]["headers"],
+        known_fusion_rows,
+        format_overview_title,
+    )
+
+if manta_tables_maxdepth.get("data"):
+    row_idx += 2
+    row_idx = write_maxdepth_rescue_summary(
+        worksheet_overview,
+        row_idx,
+        "MaxDepth rescue calls",
+        manta_tables_maxdepth,
+        format_overview_title,
     )
 
 workbook.set_size(1800, 1200)

--- a/workflow/scripts/export_to_xlsx_manta.py
+++ b/workflow/scripts/export_to_xlsx_manta.py
@@ -398,7 +398,7 @@ def write_target_summary(worksheet, start_row, title, table_data, format_heading
     )
 
 
-def create_maxdepth_bnd_rescue_table(tables_dict, blocking_filter_flags, min_support=0.05):
+def create_maxdepth_bnd_rescue_table(tables_dict, blocking_filter_flags, min_support=MAXDEPTH_RESCUE_MIN_SUPPORT):
     """
     Return BND events classified as MaxDepth if they pass our rescue criteria.
 
@@ -531,7 +531,7 @@ blocking_filter_flags = set(filter_flags) - {"MaxDepth"}
 manta_tables_maxdepth = create_maxdepth_bnd_rescue_table(
     manta_tables_all,
     blocking_filter_flags,
-    min_support == MAXDEPTH_RESCUE_MIN_SUPPORT,
+    min_support=MAXDEPTH_RESCUE_MIN_SUPPORT,
 )
 
 # 2. Creating xlsx workbook

--- a/workflow/scripts/export_to_xlsx_manta.py
+++ b/workflow/scripts/export_to_xlsx_manta.py
@@ -8,6 +8,7 @@ import logging
 import os
 from collections import Counter
 
+MAX_OVERVIEW_NORMAL_AF = 0.2
 
 logging.basicConfig(
     format="{asctime} - {levelname} - {message}",
@@ -108,85 +109,6 @@ def apply_compact_formatting(worksheet, headers, data):
         worksheet.set_column(col_idx, col_idx, final_width)
 
 
-def write_target_summary(worksheet, start_row, title, table_data, format_heading, event_atomic=False):
-    """
-    Write variants annotated as belonging to the target panel.
-
-    When event_atomic is True, all rows belonging to a selected BND event
-    are included if at least one breakend is in the target panel.
-    """
-    if not table_data or "headers" not in table_data:
-        return start_row
-
-    headers = table_data["headers"]
-    data = table_data.get("data", [])
-
-    target_col_idx = next(
-        (
-            idx
-            for idx, header in enumerate(headers)
-            if header.get("header") == "In Target Panel"
-        ),
-        None,
-    )
-
-    if target_col_idx is None:
-        return start_row
-
-    target_data = [
-        row
-        for row in data
-        if str(row[target_col_idx]).strip().lower() == "yes"
-    ]
-
-    if event_atomic and target_data:
-        columns = _column_indexes(table_data)
-
-        selected_event_ids = {
-            _bnd_event_key(row, columns)
-            for row in target_data
-        }
-
-        target_data = [
-            row
-            for row in data
-            if _bnd_event_key(row, columns) in selected_event_ids
-        ]
-
-    worksheet.write(start_row, 0, title, format_heading)
-    table_start_idx = start_row + 2
-
-    if not target_data:
-        worksheet.write(
-            table_start_idx,
-            0,
-            "Inga target-varianter hittades för denna typ.",
-        )
-        return table_start_idx + 3
-
-    column_end = convert_columns_to_letter(len(headers))
-    excel_start_row = table_start_idx + 1
-    excel_end_row = excel_start_row + len(target_data)
-    table_area = f"A{excel_start_row}:{column_end}{excel_end_row}"
-
-    worksheet.add_table(
-        table_area,
-        {
-            "columns": headers,
-            "data": target_data,
-            "style": "Table Style Light 1",
-        },
-    )
-
-    apply_compact_formatting(
-        worksheet,
-        headers,
-        target_data,
-    )
-
-    return table_start_idx + len(target_data) + 4
-
-
 def create_sheet(workbook, sheet_name, title, sample_name, filter_flags, table_data, set_cols=None):
     if not table_data or "headers" not in table_data:
         return None
@@ -269,14 +191,6 @@ def _as_float(value, default=0.0):
         return default
 
 
-def _annotation_flags(row, column_indexes):
-    return {
-        flag.strip()
-        for flag in str(row[column_indexes["annotation"]]).split(",")
-        if flag.strip()
-    }
-
-
 def _bnd_event_key(row, column_indexes):
     """Return a stable BND event key, falling back to a single-record event."""
     event_idx = column_indexes.get("bnd event id")
@@ -285,6 +199,14 @@ def _bnd_event_key(row, column_indexes):
 
     id_idx = column_indexes.get("mantaid")
     return str(row[id_idx]) if id_idx is not None else id(row)
+
+
+def _annotation_flags(row, column_indexes):
+    return {
+        flag.strip()
+        for flag in str(row[column_indexes["annotation"]]).split(",")
+        if flag.strip()
+    }
 
 
 def _is_junk_bnd(row, column_indexes):
@@ -334,13 +256,72 @@ def known_fusion_events(table):
     return selected_rows
 
 
-def write_known_fusion_summary(worksheet, start_row, title, headers, selected_data, format_heading):
-    """Write selected KNOWN_FUSION BND events to the Overview sheet."""
-    if not selected_data:
+def _filter_overview_rows_by_normal_af(table_data, selected_data, event_atomic=False):
+    """
+    Remove Overview candidates with normal-panel AF above the configured limit.
+    BND events are removed as complete events when event_atomic is True.
+    """
+    columns = _column_indexes(table_data)
+    normal_af_idx = columns.get("manta_n_af")
+
+    if normal_af_idx is None:
+        return list(selected_data)
+
+    def has_high_normal_af(row):
+        return (_as_float(row[normal_af_idx], default=0.0) > MAX_OVERVIEW_NORMAL_AF)
+
+    if not event_atomic:
+        return [row for row in selected_data if not has_high_normal_af(row)]
+
+    excluded_event_ids = {_bnd_event_key(row, columns) for row in selected_data if has_high_normal_af(row)}
+
+    return [
+        row
+        for row in selected_data
+        if _bnd_event_key(row, columns) not in excluded_event_ids
+    ]
+
+
+def write_overview_summary(
+    worksheet,
+    start_row,
+    title,
+    table_data,
+    selected_data,
+    format_heading,
+    empty_message=None,
+    event_atomic=False,
+):
+    """
+    Apply the common Overview filters and write a summary table.
+
+    BND summaries are filtered as complete events when event_atomic is True.
+    When no rows remain, the section is omitted unless empty_message is given.
+    """
+    if not table_data or "headers" not in table_data:
         return start_row
+
+    selected_data = _filter_overview_rows_by_normal_af(
+        table_data,
+        selected_data,
+        event_atomic=event_atomic,
+    )
+
+    if not selected_data and empty_message is None:
+        return start_row
+
+    headers = table_data["headers"]
 
     worksheet.write(start_row, 0, title, format_heading)
     table_start_row = start_row + 2
+
+    if not selected_data:
+        worksheet.write(
+            table_start_row,
+            0,
+            empty_message,
+        )
+        return table_start_row + 3
 
     column_end = convert_columns_to_letter(len(headers))
     excel_start_row = table_start_row + 1
@@ -356,9 +337,69 @@ def write_known_fusion_summary(worksheet, start_row, title, headers, selected_da
         },
     )
 
-    apply_compact_formatting(worksheet, headers, selected_data)
+    apply_compact_formatting(
+        worksheet,
+        headers,
+        selected_data,
+    )
 
     return table_start_row + len(selected_data) + 4
+
+
+def write_target_summary(worksheet, start_row, title, table_data, format_heading, event_atomic=False):
+    """
+    Select target-panel variants and write them to the Overview sheet.
+    When event_atomic is True, all rows belonging to a selected BND event
+    are included if at least one breakend is in the target panel.
+    """
+    if not table_data or "headers" not in table_data:
+        return start_row
+
+    headers = table_data["headers"]
+    data = table_data.get("data", [])
+
+    target_col_idx = next(
+        (
+            idx
+            for idx, header in enumerate(headers)
+            if header.get("header") == "In Target Panel"
+        ),
+        None,
+    )
+
+    if target_col_idx is None:
+        return start_row
+
+    target_data = [
+        row
+        for row in data
+        if str(row[target_col_idx]).strip().lower() == "yes"
+    ]
+
+    if event_atomic and target_data:
+        columns = _column_indexes(table_data)
+
+        selected_event_ids = {
+            _bnd_event_key(row, columns)
+            for row in target_data
+        }
+
+        target_data = [
+            row
+            for row in data
+            if _bnd_event_key(row, columns) in selected_event_ids
+        ]
+
+    return write_overview_summary(
+        worksheet,
+        start_row,
+        title,
+        table_data,
+        target_data,
+        format_heading,
+        empty_message="Inga target-varianter hittades för denna typ.",
+        event_atomic=event_atomic,
+    )
 
 
 def create_maxdepth_bnd_rescue_table(tables_dict, blocking_filter_flags, min_support=0.05):
@@ -473,31 +514,6 @@ def create_maxdepth_bnd_rescue_table(tables_dict, blocking_filter_flags, min_sup
         )
 
     return rescue_table
-
-
-def write_maxdepth_rescue_summary(worksheet, start_row, title, table_data, format_heading):
-    """Write accepted MaxDepth BND rescue calls to the Overview sheet."""
-    if not table_data or not table_data.get("data"):
-        return start_row
-
-    headers = table_data["headers"]
-    data = table_data["data"]
-
-    worksheet.write(start_row, 0, title, format_heading)
-    table_start_row = start_row + 2
-
-    column_end = convert_columns_to_letter(len(headers))
-    excel_start_row = table_start_row + 1
-    excel_end_row = excel_start_row + len(data)
-    table_area = f"A{excel_start_row}:{column_end}{excel_end_row}"
-
-    worksheet.add_table(
-        table_area,
-        {"columns": headers, "data": data, "style": "Table Style Light 1"},
-    )
-    apply_compact_formatting(worksheet, headers, data)
-
-    return table_start_row + len(data) + 4
 
 
 """ MAIN EXECUTION """
@@ -641,26 +657,35 @@ for sv_key, sv_title in summaries:
 
 known_fusion_rows = known_fusion_events(manta_tables_full["bnd"])
 
-if known_fusion_rows:
-    row_idx += 2
-    row_idx = write_known_fusion_summary(
-        worksheet_overview,
-        row_idx,
-        "Translocations (KNOWN_FUSION)",
-        manta_tables_full["bnd"]["headers"],
-        known_fusion_rows,
-        format_overview_title,
-    )
+known_fusion_start = row_idx + 2
 
-if manta_tables_maxdepth.get("data"):
-    row_idx += 2
-    row_idx = write_maxdepth_rescue_summary(
-        worksheet_overview,
-        row_idx,
-        "MaxDepth rescue calls",
-        manta_tables_maxdepth,
-        format_overview_title,
-    )
+new_row_idx = write_overview_summary(
+    worksheet_overview,
+    known_fusion_start,
+    "Translocations (KNOWN_FUSION)",
+    manta_tables_full["bnd"],
+    known_fusion_rows,
+    format_overview_title,
+    event_atomic=True,
+)
+
+if new_row_idx != known_fusion_start:
+    row_idx = new_row_idx
+
+maxdepth_start = row_idx + 2
+
+new_row_idx = write_overview_summary(
+    worksheet_overview,
+    maxdepth_start,
+    "MaxDepth rescue calls",
+    manta_tables_maxdepth,
+    manta_tables_maxdepth.get("data", []),
+    format_overview_title,
+    event_atomic=True,
+)
+
+if new_row_idx != maxdepth_start:
+    row_idx = new_row_idx
 
 workbook.set_size(1800, 1200)
 workbook.close()

--- a/workflow/scripts/export_to_xlsx_manta.py
+++ b/workflow/scripts/export_to_xlsx_manta.py
@@ -11,7 +11,7 @@ from collections import Counter
 MAX_OVERVIEW_NORMAL_AF = 0.2
 MAXDEPTH_RESCUE_MIN_SUPPORT = 0.05
 
-COLUMN_WIDTHS = {
+COLUMN_WIDTHS = {  # This is also used to order columns on Overview
     "Sample Name": 18,
     "Chr": 6,
     "Pos": 10,
@@ -19,23 +19,23 @@ COLUMN_WIDTHS = {
     "Ref": 12,
     "Alt": 24,
     "SV Length": 11,
+    "MantaID": 12,
     "Depth": 6,
     "In Target Panel": 6,
     "manta_N_OCC": 6,
     "manta_T_OCC": 6,
     "manta_N_AF": 8,
     "manta_T_AF": 8,
-    "STR %": 6,
+    "STR %": 4,
     "Paired-read freq": 6,
     "Spanning-read freq": 6,
-    "MantaID": 24,
-    "BND Event ID": 30,
-    "BreakEnd": 24,
+    "Annotation": 16,
     "Genes": 26,
     "Details": 20,
     "Hom Length": 11,
     "Hom Sequence": 18,
-    "Annotation": 16,
+    "BreakEnd": 18,
+    "BND Event ID": 30,
 }
 
 logging.basicConfig(
@@ -726,6 +726,6 @@ new_row_idx = write_overview_summary(
 if new_row_idx != maxdepth_start:
     row_idx = new_row_idx
 
-workbook.set_size(1900, 1400)
+workbook.set_size(1800, 1200)
 workbook.close()
 logging.info("All done")

--- a/workflow/scripts/export_to_xlsx_manta.py
+++ b/workflow/scripts/export_to_xlsx_manta.py
@@ -38,7 +38,7 @@ def load_target_genes(filepath):
     if not filepath:
         logging.warning("No target gene list supplied; target-panel summaries will be omitted.")
         return []
-    
+
     try:
         with open(filepath, encoding="utf-8") as gene_file:
             genes = [line.strip() for line in gene_file if line.strip()]
@@ -60,9 +60,7 @@ def load_target_genes(filepath):
 
 def format_manta_table(table, sample_name, format_2dec):
     """
-    Pre-processes the table data to:
-    1. Prepend 'Sample Name' to all rows.
-    2. Convert any frequency columns to exactly two decimal places.
+    Pre-processes the table data to add 'Sample Name' to all rows and convert freq columns to two decimal places.
     """
     if not table or "headers" not in table:
         return
@@ -110,7 +108,7 @@ def apply_compact_formatting(worksheet, headers, data):
         lower_header = header_str.lower()
         if "freq" in lower_header or "af" in lower_header or "chr" in lower_header:
             final_width = 6
-        elif "pos" in lower_header or "length" in lower_header or "sample" in lower_header:
+        elif "pos" in lower_header or "length" in lower_header:
             final_width = 12
         elif "mantaid" in lower_header:
             final_width = 16
@@ -226,7 +224,7 @@ def _is_junk_bnd(row, column_indexes):
 
 
 def known_fusion_events(table):
-    """Return complete BND events containing a KNOWN_FUSION annotation."""
+    """Return all available rows for BND events containing a KNOWN_FUSION annotation."""
     columns = _column_indexes(table)
     details_idx = columns.get("details")
 
@@ -361,7 +359,6 @@ def write_target_summary(worksheet, start_row, title, table_data, format_heading
     if not table_data or "headers" not in table_data:
         return start_row
 
-    headers = table_data["headers"]
     data = table_data.get("data", [])
 
     columns = _column_indexes(table_data)
@@ -377,7 +374,6 @@ def write_target_summary(worksheet, start_row, title, table_data, format_heading
     ]
 
     if event_atomic and target_data:
-        columns = _column_indexes(table_data)
 
         selected_event_ids = {
             _bnd_event_key(row, columns)
@@ -527,8 +523,7 @@ filter_flags = ["MinQUAL", "MinGQ", "MinSomaticScore", "Ploidy", "MaxMQ0Frac", "
 # Load target genes for easy filtering in Excel
 target_genes = []
 target_genes_path = getattr(snakemake.params, "target_genes", "") or getattr(snakemake.input, "target_genes", "")
-if target_genes_path:
-    target_genes = load_target_genes(target_genes_path)
+target_genes = load_target_genes(target_genes_path)
 
 manta_tables_full = create_manta_tables(snakemake.input.manta, filter_flags, target_genes=target_genes)
 manta_tables_all = create_manta_tables(snakemake.input.manta, avoid_filterflags=[], target_genes=target_genes)
@@ -536,7 +531,7 @@ blocking_filter_flags = set(filter_flags) - {"MaxDepth"}
 manta_tables_maxdepth = create_maxdepth_bnd_rescue_table(
     manta_tables_all,
     blocking_filter_flags,
-    min_support=0.05,
+    min_support == MAXDEPTH_RESCUE_MIN_SUPPORT,
 )
 
 # 2. Creating xlsx workbook

--- a/workflow/scripts/export_to_xlsx_manta.py
+++ b/workflow/scripts/export_to_xlsx_manta.py
@@ -12,13 +12,22 @@ MAX_OVERVIEW_NORMAL_AF = 0.2
 MAXDEPTH_RESCUE_MIN_SUPPORT = 0.05
 
 COLUMN_WIDTHS = {
-    "Sample Name": 24,
-    "Chr": 8,
-    "Pos": 11,
-    "EndPos": 11,
+    "Sample Name": 18,
+    "Chr": 6,
+    "Pos": 10,
+    "EndPos": 10,
     "Ref": 12,
     "Alt": 24,
     "SV Length": 11,
+    "Depth": 6,
+    "In Target Panel": 6,
+    "manta_N_OCC": 6,
+    "manta_T_OCC": 6,
+    "manta_N_AF": 8,
+    "manta_T_AF": 8,
+    "STR %": 6,
+    "Paired-read freq": 6,
+    "Spanning-read freq": 6,
     "MantaID": 24,
     "BND Event ID": 30,
     "BreakEnd": 24,
@@ -27,15 +36,6 @@ COLUMN_WIDTHS = {
     "Hom Length": 11,
     "Hom Sequence": 18,
     "Annotation": 16,
-    "Depth": 10,
-    "manta_N_OCC": 12,
-    "manta_T_OCC": 12,
-    "manta_N_AF": 10,
-    "manta_T_AF": 10,
-    "STR %": 8,
-    "Paired-read freq": 16,
-    "Spanning-read freq": 18,
-    "In Target Panel": 16,
 }
 
 logging.basicConfig(
@@ -157,7 +157,7 @@ def create_sheet(workbook, sheet_name, title, sample_name, filter_flags, table_d
     # Create the table with default styling. This automatically applies an autofilter.
     worksheet.add_table(
         table_area,
-        {"columns": headers, "data": data, "style": "Table Style Light 1"},
+        {"columns": excel_headers(headers), "data": data, "style": "Table Style Light 1"},
     )
 
     apply_compact_formatting(worksheet, headers, data)
@@ -224,6 +224,17 @@ def _is_junk_bnd(row, column_indexes):
     )
 
 
+def excel_headers(headers):
+    """Create display-only Excel headers."""
+    return [
+        {
+            **header,
+            "header": header.get("header", "").replace("manta_", "", 1),
+        }
+        for header in headers
+    ]
+
+
 def known_fusion_events(table):
     """Return all available rows for BND events containing a KNOWN_FUSION annotation."""
     columns = _column_indexes(table)
@@ -262,6 +273,36 @@ def has_high_normal_af(row, normal_af_idx):
         normal_af_idx is not None
         and _as_float(row[normal_af_idx], default=0.0) > MAX_OVERVIEW_NORMAL_AF
     )
+
+
+def align_overview_table(table_data, selected_data):
+    """Put Overview fields in the fixed COLUMN_WIDTHS order."""
+    source_headers = table_data["headers"]
+    source_indexes = {
+        header.get("header"): index
+        for index, header in enumerate(source_headers)
+    }
+
+    headers = []
+    for name in COLUMN_WIDTHS:
+        if name in source_indexes:
+            headers.append(
+                dict(source_headers[source_indexes[name]])
+            )
+        else:
+            headers.append({"header": name})
+
+    aligned_data = [
+        [
+            row[source_indexes[name]]
+            if name in source_indexes
+            else ""
+            for name in COLUMN_WIDTHS
+        ]
+        for row in selected_data
+    ]
+
+    return headers, aligned_data
 
 
 def _filter_overview_rows_by_normal_af(table_data, selected_data, event_atomic=False):
@@ -315,8 +356,10 @@ def write_overview_summary(
     if not selected_data and empty_message is None:
         return start_row
 
-    headers = table_data["headers"]
-
+    headers, selected_data = align_overview_table(
+        table_data,
+        selected_data,
+    )
     worksheet.write(start_row, 0, title, format_heading)
     table_start_row = start_row + 2
 
@@ -336,7 +379,7 @@ def write_overview_summary(
     worksheet.add_table(
         table_area,
         {
-            "columns": headers,
+            "columns": excel_headers(headers),
             "data": selected_data,
             "style": "Table Style Light 1",
         },
@@ -683,6 +726,6 @@ new_row_idx = write_overview_summary(
 if new_row_idx != maxdepth_start:
     row_idx = new_row_idx
 
-workbook.set_size(1800, 1200)
+workbook.set_size(1900, 1400)
 workbook.close()
 logging.info("All done")


### PR DESCRIPTION
* Updated report with full manta-id and added manta_N and T AF to export_to_xlsx_create_tables.py
* removed the problematic maxdepth filter and switched to a 2-pass strategy in export_to_xlsx_manta.py where the second pass extracts BND events previously filtered as maxdepth and adds these as separate table in Overview if they have 0 support in normal panel if they have > 5% PR or SR support
* added a separate Overview table for KNOWN_FUSION events
* modified column widths and order for overview sheet